### PR TITLE
Fix invalid argument if no OpenID providers present

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,11 +32,13 @@ class Application extends App
             }
         }
         $providers = json_decode($config->getAppValue($this->appName, 'openid_providers', '[]'), true);
-        foreach ($providers as $provider) {
-            \OC_App::registerLogIn([
-                'name' => ucfirst($provider['title']),
-                'href' => $urlGenerator->linkToRoute($this->appName.'.login.openid', ['provider'=>$provider['title']]),
-            ]);
+        if (is_array($providers) || is_object($providers))
+            foreach ($providers as $provider) {
+                \OC_App::registerLogIn([
+                    'name' => ucfirst($provider['title']),
+                    'href' => $urlGenerator->linkToRoute($this->appName.'.login.openid', ['provider'=>$provider['title']]),
+                ]);
+            }
         }
         if ($config->getAppValue($this->appName, 'allow_login_connect')) {
             \OCP\App::registerPersonal($this->getContainer()->getAppName(), 'appinfo/personal');


### PR DESCRIPTION
If no OpenID provider was present, the json_decode would return null instead of an array and cause the log to be flooded with invalid argument exceptions.