### PR TITLE
Allow automatic login redirect

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -4,3 +4,18 @@ require __DIR__ . '/../3rdparty/autoload.php';
 
 $app = new \OCA\SocialLogin\AppInfo\Application();
 $app->register();
+
+$userSession = \OC::$server->getUserSession();
+$config = \OC::$server->getConfig();
+
+if(!$userSession->isLoggedIn() &&
+	\OC::$server->getRequest()->getPathInfo() === '/login') {
+		$autoRedirect = $config->getAppValue('sociallogin', 'auto_redirect');
+		$alternativeLogins = \OC_App::getAlternativeLogins();
+
+		if($autoRedirect && count($alternativeLogins)==1){
+			$url = $alternativeLogins[0]['href'];
+			header('Location: ' . $url);
+			exit();
+		}
+}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -39,11 +39,12 @@ class SettingsController extends Controller
         $this->socialConnect = $socialConnect;
     }
 
-    public function saveAdmin($new_user_group, $disable_registration, $allow_login_connect, $providers, $openid_providers, $custom_oidc_providers)
+    public function saveAdmin($new_user_group, $disable_registration, $allow_login_connect, $auto_redirect, $providers, $openid_providers, $custom_oidc_providers)
     {
         $this->config->setAppValue($this->appName, 'new_user_group', $new_user_group);
         $this->config->setAppValue($this->appName, 'disable_registration', $disable_registration ? true : false);
         $this->config->setAppValue($this->appName, 'allow_login_connect', $allow_login_connect ? true : false);
+        $this->config->setAppValue($this->appName, 'auto_redirect', $auto_redirect ? true : false);
         $this->config->setAppValue($this->appName, 'oauth_providers', json_encode($providers));
         $this->config->setAppValue($this->appName, 'openid_providers', json_encode(array_values($openid_providers)));
         $this->config->setAppValue($this->appName, 'custom_oidc_providers', json_encode(array_values($custom_oidc_providers)));

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -36,6 +36,7 @@ class AdminSettings implements ISettings
             'new_user_group',
             'disable_registration',
             'allow_login_connect',
+            'auto_redirect'
         ];
         $oauthProviders = [
             'facebook',

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -13,6 +13,10 @@
 			<?php endforeach ?>
 		</select>
 		<div>
+			<input id="auto_redirect" type="checkbox" class="checkbox" name="auto_redirect" value="1" <?php p($_['auto_redirect'] ? 'checked' : '') ?>/>
+			<label for="auto_redirect"><?php p($l->t('Automatically redirect if only one social login is configured')) ?></label>
+		</div>
+		<div>
 			<input id="disable_registration" type="checkbox" class="checkbox" name="disable_registration" value="1" <?php p($_['disable_registration'] ? 'checked' : '') ?>/>
 			<label for="disable_registration"><?php p($l->t('Disable auto create new users')) ?></label>
 		</div>


### PR DESCRIPTION
If only one alternative login method is configured, allow direct redirection to the social login provider, without showing the nextcloud login page (depending on a configuration).