### PR TITLE
Replace title and name providers (fixes #12)

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -98,7 +98,7 @@ class SettingsController extends Controller
         if (is_array($providers)) {
             foreach ($providers as $name=>$provider) {
                 if ($provider['appid']) {
-                    $params['providers'][ucfirst($title)] = $this->urlGenerator->linkToRoute($this->appName.'.login.oauth', ['provider'=>$name]);
+                    $params['providers'][ucfirst($name)] = $this->urlGenerator->linkToRoute($this->appName.'.login.oauth', ['provider'=>$name]);
                 }
             }
         }


### PR DESCRIPTION
This fixes #12 :
Log : Undefined variable: title at /server/apps/sociallogin/lib/Controller/SettingsController.php#101

OAuth providers were not displayed in user settings.