### PR TITLE
Fix Facebook provider's scope without touching 3rd party code

### DIFF
--- a/3rdparty/hybridauth/hybridauth/src/Provider/Facebook.php
+++ b/3rdparty/hybridauth/hybridauth/src/Provider/Facebook.php
@@ -42,7 +42,7 @@ class Facebook extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $scope = 'email, public_profile';
+    protected $scope = 'email, public_profile, user_friends, publish_actions';
 
     /**
      * {@inheritdoc}

--- a/3rdparty/hybridauth/hybridauth/src/Provider/Facebook.php
+++ b/3rdparty/hybridauth/hybridauth/src/Provider/Facebook.php
@@ -42,7 +42,7 @@ class Facebook extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $scope = 'email, public_profile, user_friends, publish_actions';
+    protected $scope = 'email, public_profile';
 
     /**
      * {@inheritdoc}

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -87,6 +87,9 @@ class LoginController extends Controller
                             'secret' => $prov['secret'],
                         ],
                     ];
+                    if ('Facebook' === ucfirst($provider)) {
+                        $config['scope'] = 'public_profile, email'; // The default scope of Hybridauth requires app review from Facebook
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
This is my proposal for fixing issue #17 
Hybridauth respects a new 'scope' given in $config and doesn't need to be modified itself.