### PR TITLE
prevent creating account if email exists

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -248,7 +248,8 @@ class LoginController extends Controller
             if ($this->config->getAppValue($this->appName, 'disable_registration')) {
                 throw new LoginException($this->l->t('Auto creating new users is disabled'));
             }
-            if (count($this->userManager->getByEmail($profile->email)) !== 0) {
+            if ($this->config->getAppValue($this->appName, 'prevent_create_email_exists') &&
+            	count($this->userManager->getByEmail($profile->email)) !== 0) {
             	throw new LoginException($this->l->t('Email already registered'));
             }
             $password = substr(base64_encode(random_bytes(64)), 0, 30);

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -248,6 +248,9 @@ class LoginController extends Controller
             if ($this->config->getAppValue($this->appName, 'disable_registration')) {
                 throw new LoginException($this->l->t('Auto creating new users is disabled'));
             }
+            if (count($this->userManager->getByEmail($profile->email)) !== 0) {
+            	throw new LoginException($this->l->t('Email already registered'));
+            }
             $password = substr(base64_encode(random_bytes(64)), 0, 30);
             $user = $this->userManager->createUser($uid, $password);
             $user->setDisplayName((string)$profile->displayName);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -48,6 +48,7 @@ class SettingsController extends Controller
         $new_user_group,
         $disable_registration,
         $allow_login_connect,
+        $prevent_create_email_exists,
         $providers,
         $openid_providers,
         $custom_oidc_providers,
@@ -56,6 +57,7 @@ class SettingsController extends Controller
         $this->config->setAppValue($this->appName, 'new_user_group', $new_user_group);
         $this->config->setAppValue($this->appName, 'disable_registration', $disable_registration ? true : false);
         $this->config->setAppValue($this->appName, 'allow_login_connect', $allow_login_connect ? true : false);
+        $this->config->setAppValue($this->appName, 'prevent_create_email_exists', $prevent_create_email_exists ? true : false);
         $this->config->setAppValue($this->appName, 'oauth_providers', json_encode($providers));
 
         try {

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -36,6 +36,7 @@ class AdminSettings implements ISettings
             'new_user_group',
             'disable_registration',
             'allow_login_connect',
+            'prevent_create_email_exists',
         ];
         $oauthProviders = [
             'facebook',

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -143,6 +143,10 @@ $providersData = [
             <input id="allow_login_connect" type="checkbox" class="checkbox" name="allow_login_connect" value="1" <?php p($_['allow_login_connect'] ? 'checked' : '') ?>/>
             <label for="allow_login_connect"><?php p($l->t('Allow users to connect social logins with their account')) ?></label>
         </div>
+        <div>
+            <input id="prevent_create_email_exists" type="checkbox" class="checkbox" name="prevent_create_email_exists" value="1" <?php p($_['prevent_create_email_exists'] ? 'checked' : '') ?>/>
+            <label for="prevent_create_email_exists"><?php p($l->t('Prevent creating an account if the email address exists in another account')) ?></label>
+        </div>
         </p>
         <hr/>
         <?php foreach ($_['providers'] as $name => $provider): ?>


### PR DESCRIPTION
A user should not be able to register another account if they already have an account, I have made a change to check if the email address is already in the system.