### PR TITLE
Add possibility to autocreate groups and use mapping

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -49,6 +49,7 @@ class SettingsController extends Controller
         $allow_login_connect,
         $prevent_create_email_exists,
         $update_profile_on_login,
+        $auto_create_groups,
         $providers,
         $tg_bot,
         $tg_token,
@@ -57,10 +58,12 @@ class SettingsController extends Controller
         $custom_oidc_providers,
         $custom_oauth2_providers
     ) {
+
         $this->config->setAppValue($this->appName, 'disable_registration', $disable_registration ? true : false);
         $this->config->setAppValue($this->appName, 'allow_login_connect', $allow_login_connect ? true : false);
         $this->config->setAppValue($this->appName, 'prevent_create_email_exists', $prevent_create_email_exists ? true : false);
         $this->config->setAppValue($this->appName, 'update_profile_on_login', $update_profile_on_login ? true : false);
+        $this->config->setAppValue($this->appName, 'auto_create_groups', $auto_create_groups ? true : false);
         $this->config->setAppValue($this->appName, 'oauth_providers', json_encode($providers));
         $this->config->setAppValue($this->appName, 'tg_bot', $tg_bot);
         $this->config->setAppValue($this->appName, 'tg_token', $tg_token);

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -37,6 +37,7 @@ class AdminSettings implements ISettings
             'allow_login_connect',
             'prevent_create_email_exists',
             'update_profile_on_login',
+            'auto_create_groups'
         ];
         $oauthProviders = [
             'google',

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -165,6 +165,10 @@ $providersData = [
                 <input id="update_profile_on_login" type="checkbox" class="checkbox" name="update_profile_on_login" value="1" <?php p($_['update_profile_on_login'] ? 'checked' : '') ?>/>
                 <label for="update_profile_on_login"><?php p($l->t('Update user profile every login')) ?></label>
             </div>
+            <div>
+                <input id="auto_create_groups" type="checkbox" class="checkbox" name="auto_create_groups" value="1" <?php p($_['auto_create_groups'] ? 'checked' : '') ?>/>
+                <label for="auto_create_groups"><?php p($l->t('Automatically create groups if they do not exists.')) ?></label>
+            </div>
         </p>
         <button><?php p($l->t('Save')); ?></button>
         <hr/>


### PR DESCRIPTION
Hi,

Currently it is only possible to use the group/roles mapping or the auto creation of groups. I would like to use a combination of both. This PR makes it possible to auto create a group for every specified group in the API response and also like the user to mapped groups. 

The old behaviour is still possible by just leaving the auto create checkbox off or not specifying a mapping.

I also fixed a little bug by this PR. Currently it is not possible to manually add groups to a user since this is overwritten on login. After this PR only groups that are managed by the mapping or start with the providerPrefix are removed from the user on login.

I would like to hear some feedback.

Fixes #96 