### PR TITLE
Set correct redirect URL for Google SSO setup

### DIFF
--- a/docs/sso/google.md
+++ b/docs/sso/google.md
@@ -1,5 +1,7 @@
 # How to Setup Google SSO
 
+These instructions assume "https://example.com/" is the base URL for your NextCloud. Adjust according to your setup.
+
 1. Install the app (see README.md)
 2. Setup a Google Authorized Domain
     1. Go to Google Webmaster Tools: https://www.google.com/webmasters/tools/
@@ -29,7 +31,6 @@
     3. In the bottom section under "Google" enter:
         * App id: the "client ID" provided earlier
         * Secret: the "client secret" provided earlier
-        * Default group: "admin" or whatever user group you want new users assigned to
-        * Allow login only from specified domain: (you can leave this blank)
+        * Default group: Select the group you want users to be assigned
     4. Click "Save" at the very bottom
 5. Now, open up a new browser to test the login. On the login screen you should now see "Google" underneath the typical NextCloud login prompt.

--- a/docs/sso/google.md
+++ b/docs/sso/google.md
@@ -20,7 +20,7 @@
     8. Click "Web application" for application type and enter values:
         * Name: something relevant
         * Authorized JavaScript origins: https://example.com (then hit ENTER; see setup of authorized domains if there's an error)
-        * Authorized redirect URIs: https://example.com (then hit ENTER; see setup of authorized domains if there's an error)
+        * Authorized redirect URIs: https://example.com/apps/sociallogin/oauth/google (then hit ENTER; see setup of authorized domains if there's an error)
     9. Click "Save"
     10. You should see a "client ID" and "client secret"; store these somewhere safe
 4. Configure "Social Login" in NextCloud


### PR DESCRIPTION
Follow up to https://github.com/zorn-v/nextcloud-social-login/pull/111

The Redirect URL must be the path to sociallogin app.