### PR TITLE
Fix for #117: prune user membership groups when IdP does not provide an (expected) group claim because it's empty

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -366,7 +366,11 @@ class LoginController extends Controller
                 } catch (\Exception $e) {}
             }
 
-            if (!empty($profile->data['groups']) && is_array($profile->data['groups'])) {
+            # we assume here that $profile->data['groups'] can either be:
+            # - null, when there is no information on groups the user is a member of
+            # - empty array, which means the user explicitly is not a member of any groups
+            # - a non-empty array, listing the groups the user is a member of
+            if (is_array($profile->data['groups'])) {
                 $groupNames = $profile->data['groups'];
                 $groupMapping = isset($profile->data['group_mapping']) ? $profile->data['group_mapping'] : null;
                 $userGroups = $this->groupManager->getUserGroups($user);

--- a/lib/Provider/CustomOAuth2.php
+++ b/lib/Provider/CustomOAuth2.php
@@ -62,12 +62,15 @@ class CustomOAuth2 extends OAuth2
     protected function getGroups(Data\Collection $data)
     {
         $groupsClaim = $this->config->get('groups_claim');
-        if ($groups = $data->get($groupsClaim)) {
-            if (is_array($groups)) {
-                return $groups;
-            } elseif (is_string($groups)) {
-                return $this->strToArray($groups);
+        if (!empty($groupsClaim)) {
+            if ($groups = $data->get($groupsClaim)) {
+                if (is_array($groups)) {
+                    return $groups;
+                } elseif (is_string($groups)) {
+                    return $this->strToArray($groups);
+                }
             }
+            return array();
         }
         return null;
     }

--- a/lib/Provider/CustomOAuth2.php
+++ b/lib/Provider/CustomOAuth2.php
@@ -49,7 +49,8 @@ class CustomOAuth2 extends OAuth2
             }
         }
 
-        if ($groups = $this->getGroups($data)) {
+        $groups = $this->getGroups($data)
+        if (is_array($groups)) {
             $userProfile->data['groups'] = $groups;
         }
         if ($groupMapping = $this->config->get('group_mapping')) {

--- a/lib/Provider/CustomOAuth2.php
+++ b/lib/Provider/CustomOAuth2.php
@@ -49,7 +49,7 @@ class CustomOAuth2 extends OAuth2
             }
         }
 
-        $groups = $this->getGroups($data)
+        $groups = $this->getGroups($data);
         if (is_array($groups)) {
             $userProfile->data['groups'] = $groups;
         }

--- a/lib/Provider/CustomOpenIDConnect.php
+++ b/lib/Provider/CustomOpenIDConnect.php
@@ -63,7 +63,15 @@ class CustomOpenIDConnect extends CustomOAuth2
             if (empty($userProfile->email)) {
                 $userProfile->email = $profile->get('email');
             }
-            if (!is_array($userProfile->data['groups'])) {
+            # using empty() here instead of is_array()
+            # since the call to getGroups() above could have returned
+            # an empty array since relevant claims might have not been
+            # included in the particular response
+            # 
+            # this is a follow-up going to userinfo URL
+            # so it's fine to make sure if there are no groups
+            # for this user
+            if (empty($userProfile->data['groups'])) {
                 $groups = $this->getGroups($profile);
                 if ($groups !== null) {
                     $userProfile->data['groups'] = $groups;

--- a/lib/Provider/CustomOpenIDConnect.php
+++ b/lib/Provider/CustomOpenIDConnect.php
@@ -35,7 +35,8 @@ class CustomOpenIDConnect extends CustomOAuth2
         $userProfile->displayName = $data->get('name');
         $userProfile->photoURL    = $data->get('picture');
         $userProfile->email       = $data->get('email');
-        if ($groups = $this->getGroups($data)) {
+        $groups = $this->getGroups($data);
+        if ($groups !== null) {
             $userProfile->data['groups'] = $groups;
         }
         if ($groupMapping = $this->config->get('group_mapping')) {
@@ -62,8 +63,11 @@ class CustomOpenIDConnect extends CustomOAuth2
             if (empty($userProfile->email)) {
                 $userProfile->email = $profile->get('email');
             }
-            if (empty($userProfile->data['groups']) && $groups = $this->getGroups($profile)) {
-                $userProfile->data['groups'] = $groups;
+            if (!is_array($userProfile->data['groups'])) {
+                $groups = $this->getGroups($profile);
+                if ($groups !== null) {
+                    $userProfile->data['groups'] = $groups;
+                }
             }
         }
 


### PR DESCRIPTION
The idea is that if `groups_claim` config setting is set to something, we should expect a groups claim. If there is none, we can *assume* that this means the user is not a member of any groups.

This should not affect situations when `groups_claim` is not set, but code review welcome!