### PR TITLE
Add Slack as preconfigured OAuth provider

### DIFF
--- a/3rdparty/hybridauth/hybridauth/src/Data/Collection.php
+++ b/3rdparty/hybridauth/hybridauth/src/Data/Collection.php
@@ -135,8 +135,8 @@ final class Collection
     {
         $properties = [];
 
-        foreach ($this->collection as $property) {
-            $properties[] = $property;
+        foreach ($this->collection as $key => $value) {
+            $properties[] = $key;
         }
 
         return $properties;
@@ -151,8 +151,8 @@ final class Collection
     {
         $values = [];
 
-        foreach ($this->collection as $property) {
-            $values[] = $this->get($property);
+        foreach ($this->collection as $value) {
+            $values[] = $value;
         }
 
         return $values;

--- a/3rdparty/hybridauth/hybridauth/src/Provider/Slack.php
+++ b/3rdparty/hybridauth/hybridauth/src/Provider/Slack.php
@@ -1,0 +1,96 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2019 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Provider;
+
+use Hybridauth\Adapter\OAuth2;
+use Hybridauth\Exception\UnexpectedApiResponseException;
+use Hybridauth\Data;
+use Hybridauth\User;
+
+/**
+ * Slack OAuth2 provider adapter.
+ */
+class Slack extends OAuth2
+{
+    /**
+    * {@inheritdoc}
+    */
+    public $scope = 'identity.basic identity.email identity.avatar';
+
+    /**
+    * {@inheritdoc}
+    */
+    protected $apiBaseUrl = 'https://slack.com/';
+
+    /**
+    * {@inheritdoc}
+    */
+    protected $authorizeUrl = 'https://slack.com/oauth/authorize';
+
+    /**
+    * {@inheritdoc}
+    */
+    protected $accessTokenUrl = 'https://slack.com/api/oauth.access';
+
+    /**
+    * {@inheritdoc}
+    */
+    protected $apiDocumentation = 'https://api.slack.com/docs/sign-in-with-slack';
+
+    /**
+    * {@inheritdoc}
+    */
+    public function getUserProfile()
+    {
+        $response = $this->apiRequest('api/users.identity');
+
+        $data = new Data\Collection($response);
+
+        if (! $data->exists('ok') || ! $data->get('ok')) {
+            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+        }
+
+        $userProfile = new User\Profile();
+
+        $userProfile->identifier  = $data->filter('user')->get('id');
+        $userProfile->displayName = $data->filter('user')->get('name');
+        $userProfile->email       = $data->filter('user')->get('email');
+        $userProfile->photoURL    = $this->findLargestImage($data);
+
+        return $userProfile;
+    }
+
+    /**
+    * Returns the url of the image with the highest resolution in the user object.
+    *
+    * Slack sends multiple image urls with different resolutions. As they make no guarantees
+    * which resolutions will be included we have to search all <code>image_*</code> properties
+    * for the one with the highest resolution. The resolution is attached to the property
+     * name such as <code>image_32</code> or <code>image_192</code>.
+    *
+    * @param Data\Collection $data response object as returned by <code>api/users.identity</code>
+    * @return string|null the value of the <code>image_*</code> property with the highest resolution.
+    */
+    private function findLargestImage(Data\Collection $data)
+    {
+        $maxSize = 0;
+        foreach ($data->filter('user')->properties() as $property) {
+            if (preg_match('/^image_(\d+)$/', $property, $matches) === 1) {
+                $availableSize = (int) $matches[1];
+                if ($maxSize < $availableSize) {
+                    $maxSize = $availableSize;
+                }
+            }
+        }
+        if ($maxSize > 0) {
+            return $data->filter('user')->get('image_' . $maxSize);
+        }
+        return null;
+    }
+
+}

--- a/3rdparty/hybridauth/hybridauth/src/Provider/TwitchTV.php
+++ b/3rdparty/hybridauth/hybridauth/src/Provider/TwitchTV.php
@@ -55,7 +55,7 @@ class TwitchTV extends OAuth2
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
-        $users = $data->filter('data')->properties();
+        $users = $data->filter('data')->values();
         $user = new Data\Collection($users[0]);
 
         $userProfile = new User\Profile();

--- a/css/style.css
+++ b/css/style.css
@@ -31,6 +31,10 @@
   background-image: url(../img/button/discord.svg);
   width: 21px;
 }
+#alternative-logins a.button[href*="/sociallogin/oauth/slack"]::before {
+  background-image: url(../img/button/slack.svg);
+  width: 21px;
+}
 
 #alternative-logins a.button[href*="/sociallogin/oauth/facebook"],
 #alternative-logins a.button[href*="/sociallogin/oauth/google"],
@@ -38,6 +42,7 @@
 #alternative-logins a.button[href*="/sociallogin/oauth/twitter"],
 #alternative-logins a.button[href*="/sociallogin/oauth/GitHub"],
 #alternative-logins a.button[href*="/sociallogin/oauth/discord"],
+#alternative-logins a.button[href*="/sociallogin/oauth/slack"],
 #alternative-logins a.button.gitlab,
 #alternative-logins a.button.openid,
 #alternative-logins a.button.paypal,
@@ -66,6 +71,9 @@
 }
 #alternative-logins a.button[href*="/sociallogin/oauth/discord"] {
   background-color: #7289DA;
+}
+#alternative-logins a.button[href*="/sociallogin/oauth/slack"] {
+  background-color: #333333;
 }
 #alternative-logins a.button.gitlab {
   background-color: #3f3177;

--- a/img/button/slack.svg
+++ b/img/button/slack.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 122.8 122.8"
+   xml:space="preserve"
+   sodipodi:docname="Slack_Mark_Monochrome_White.svg"
+   width="122.8"
+   height="122.8"
+   inkscape:version="0.92.4 (unknown)"><metadata
+   id="metadata35"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs33" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1680"
+   inkscape:window-height="986"
+   id="namedview31"
+   showgrid="false"
+   fit-margin-top="0"
+   fit-margin-left="0"
+   fit-margin-right="0"
+   fit-margin-bottom="0"
+   inkscape:zoom="0.87407407"
+   inkscape:cx="43.666949"
+   inkscape:cy="61.4"
+   inkscape:window-x="0"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:#FFFFFF;}
+</style>
+<g
+   id="g28"
+   transform="translate(-73.6,-73.6)">
+	<g
+   id="g8">
+		<path
+   class="st0"
+   d="m 99.4,151.2 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 h 12.9 z"
+   id="path4"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+		<path
+   class="st0"
+   d="m 105.9,151.2 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 v 32.3 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 0,0 0,-32.3 0,-32.3 z"
+   id="path6"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+	</g>
+	<g
+   id="g14">
+		<path
+   class="st0"
+   d="m 118.8,99.4 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 v 12.9 z"
+   id="path10"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+		<path
+   class="st0"
+   d="m 118.8,105.9 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 H 86.5 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 0,0 32.3,0 32.3,0 z"
+   id="path12"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+	</g>
+	<g
+   id="g20">
+		<path
+   class="st0"
+   d="m 170.6,118.8 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 h -12.9 z"
+   id="path16"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+		<path
+   class="st0"
+   d="m 164.1,118.8 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 V 86.5 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 z"
+   id="path18"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+	</g>
+	<g
+   id="g26">
+		<path
+   class="st0"
+   d="m 151.2,170.6 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 v -12.9 z"
+   id="path22"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+		<path
+   class="st0"
+   d="m 151.2,164.1 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 h 32.3 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 z"
+   id="path24"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+	</g>
+</g>
+</svg>

--- a/img/slack.svg
+++ b/img/slack.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 122.8 122.8"
+   xml:space="preserve"
+   sodipodi:docname="Slack_Mark.svg"
+   width="122.8"
+   height="122.8"
+   inkscape:version="0.92.4 (unknown)"><metadata
+   id="metadata35"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs33" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1680"
+   inkscape:window-height="986"
+   id="namedview31"
+   showgrid="false"
+   fit-margin-top="0"
+   fit-margin-left="0"
+   fit-margin-right="0"
+   fit-margin-bottom="0"
+   inkscape:zoom="0.87407407"
+   inkscape:cx="43.666949"
+   inkscape:cy="61.4"
+   inkscape:window-x="0"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:#E01E5A;}
+	.st1{fill:#36C5F0;}
+	.st2{fill:#2EB67D;}
+	.st3{fill:#ECB22E;}
+</style>
+<g
+   id="g28"
+   transform="translate(-73.6,-73.6)">
+	<g
+   id="g8">
+		<path
+   class="st0"
+   d="m 99.4,151.2 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 h 12.9 z"
+   id="path4"
+   inkscape:connector-curvature="0"
+   style="fill:#e01e5a" />
+		<path
+   class="st0"
+   d="m 105.9,151.2 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 v 32.3 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 z"
+   id="path6"
+   inkscape:connector-curvature="0"
+   style="fill:#e01e5a" />
+	</g>
+	<g
+   id="g14">
+		<path
+   class="st1"
+   d="m 118.8,99.4 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 v 12.9 z"
+   id="path10"
+   inkscape:connector-curvature="0"
+   style="fill:#36c5f0" />
+		<path
+   class="st1"
+   d="m 118.8,105.9 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 H 86.5 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 z"
+   id="path12"
+   inkscape:connector-curvature="0"
+   style="fill:#36c5f0" />
+	</g>
+	<g
+   id="g20">
+		<path
+   class="st2"
+   d="m 170.6,118.8 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 h -12.9 z"
+   id="path16"
+   inkscape:connector-curvature="0"
+   style="fill:#2eb67d" />
+		<path
+   class="st2"
+   d="m 164.1,118.8 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 V 86.5 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 z"
+   id="path18"
+   inkscape:connector-curvature="0"
+   style="fill:#2eb67d" />
+	</g>
+	<g
+   id="g26">
+		<path
+   class="st3"
+   d="m 151.2,170.6 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 v -12.9 z"
+   id="path22"
+   inkscape:connector-curvature="0"
+   style="fill:#ecb22e" />
+		<path
+   class="st3"
+   d="m 151.2,164.1 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 h 32.3 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 z"
+   id="path24"
+   inkscape:connector-curvature="0"
+   style="fill:#ecb22e" />
+	</g>
+</g>
+</svg>

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -50,6 +50,7 @@ class AdminSettings implements ISettings
             'twitter',
             'GitHub',
             'discord',
+            'slack',
         ];
         $groupNames = [];
         $groups = $this->groupManager->search('');


### PR DESCRIPTION
This is a companion pull request for a pull request hybridauth/hybridauth#1130 in the hybridauth repository. It builds on the Slack provider added to hybridauth by the other pull request and makes it available in nextcloud-social-login. 

It makes only sense to apply this pull request after hybridauth has excepted the other pull request and the dependency in nextcloud-social-plugin is updated.