### PR TITLE
Modify "log in with" Language file for different language

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -28,6 +28,6 @@
   "Default group": "Standard Gruppe für Benutzer",
   "Add group mapping": "Neue Gruppe zuweisen",
   "Custom OAuth2": "Eigener OAuth Server",
-  "Log in with": "Anmelden mit"
+  "Log in with %s": "Anmelden mit %s"
 },"pluralForm" :"nplurals=2; plural=(n > 1);"
 }

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -26,7 +26,7 @@
   "Restrict login for users without mapped groups": "Запрещать вход пользователям без ассоциированных групп",
   "Your user group is not allowed to login, please contact support": "Вход для вашей группы пользователей запрещен, пожалуйста свяжитесь с техподдержкой",
   "User %s (%s) just created via social login": "Пользователь %s (%s) создан через social login",
-  "Log in with": "Войти через",
+  "Log in with %s": "Войти через %s",
   "Disable notify admins about new users": "Отключить оповещение администраторов о новых пользователях",
   "Create users with disabled account": "Создавать пользователей с отключенным аккаунтом"
 },"pluralForm" :"nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);"

--- a/l10n/zh_CN.json
+++ b/l10n/zh_CN.json
@@ -4,6 +4,7 @@
   "Save": "保存",
   "Enabled": "启用",
   "Disable auto create new users": "取消自动创建使用者",
+  "Create users with disabled account": "默认创建禁用的用户",
   "Unknown %s provider: \"%s\"": "未知的提供者 \"%s\"",
   "Auto creating new users is disabled": "自动创建使用者功能已被关闭",
   "This account already connected": "使用者账号已经与该社交账号建立过连接",
@@ -13,6 +14,23 @@
   "Invalid provider name \"%s\". Allowed characters \"0-9a-z_.@-\"": "提供者名称 \"%s\" 无效。 只允许包含 \"0-9a-z_.@-\"",
   "Social login connect": "连接社交账号登录",
   "Available providers": "请点击下方项目进行登录",
-  "Prevent creating an account if the email address exists in another account":"如果社交账号的邮箱已经注册过Nextcloud,则不自动创建新的使用者"
+  "Social login connect is disabled": "社交账号登陆禁用",
+  "Email already registered": "这个邮箱已经注册过了",
+  "Prevent creating an account if the email address exists in another account": "如果社交账号的邮箱已经注册过Nextcloud,则不自动创建新的使用者",
+  "Disable password confirmation on settings change": "改变设置不需要验证密码",
+  "Update user profile every login": "每次登陆自动更新用户信息",
+  "Automatically create groups if they do not exists": "自动创造不存在的组",
+  "Restrict login for users without mapped groups": "限制没有分组的用户登陆",
+  "Do not prune not available user groups on login": "登陆时不清理不存在的用户组",
+  "Internal name": "内部名字",
+  "Title": "名字",
+  "Disable notify admins about new users": "关闭新用户注册通知",
+  "Authorize url": "授权URL",
+  "User info URL (optional)": "用户信息URL(可选)",
+  "Default group": "默认用户组",
+  "Add group mapping": "添加绑定组",
+  "Custom OAuth2": "自定义 OAuth2",
+  "Log in with %s": "使用 %s 账号登陆"
 },"pluralForm" :"nplurals=1; plural=0;"
 }
+

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -87,7 +87,7 @@ class Application extends App
                         'login_redirect_url' => $this->redirectUrl
                     ]);
                     \OC_App::registerLogIn([
-                        'name' => $l->t('Log in with') . ' ' . ucfirst($name),
+                        'name' => $l->t('Log in with %s', ucfirst($name)),
                         'href' => $this->providerUrl,
                     ]);
                 }
@@ -124,7 +124,7 @@ class Application extends App
                     'login_redirect_url' => $this->redirectUrl
                 ]);
                 \OC_App::registerLogIn([
-                    'name' => $l->t('Log in with') . ' ' . $provider['title'],
+                    'name' => $l->t('Log in with %s', $provider['title']),
                     'href' => $this->providerUrl,
                     'style' => isset($provider['style']) ? $provider['style'] : '',
                 ]);


### PR DESCRIPTION
I suggest a change to language files. It is better to replace "log in with" with "log in with %s". So different languages can tweak and move provider name.
Chinese is a different language, unlike English. In Chinese, it is better to say things like "使用 %s 登陆", but it is weird to say something like "使用社交账号登陆 %s".

I have modified all related l10n files and Application files. Thank you.