### PR TITLE
Fix converting JWT token

### DIFF
--- a/lib/Provider/CustomOpenIDConnect.php
+++ b/lib/Provider/CustomOpenIDConnect.php
@@ -16,7 +16,8 @@ class CustomOpenIDConnect extends CustomOAuth2
             //get payload from id_token
             $parts = explode('.', $idToken);
             list($headb64, $payload) = $parts;
-            $data = base64_decode($payload);
+            // JWT token is base64url encoded
+            $data = base64_decode(str_pad(strtr($payload, '-_', '+/'), strlen($payload) % 4, '=', STR_PAD_RIGHT));
             $this->storeData('user_data', $data);
         } else {
             throw new Exception('No id_token was found.');


### PR DESCRIPTION
According to documentation of JWT tokens (see https://jwt.io/introduction/), they use base64url encoding, not normal base64. This problem probably happen just when base64 encoded data contains characters outside ASCII range.

This will fix #52.