### PR TITLE
Support OIDC's preferred_username.

### DIFF
--- a/lib/Provider/CustomOpenIDConnect.php
+++ b/lib/Provider/CustomOpenIDConnect.php
@@ -36,6 +36,7 @@ class CustomOpenIDConnect extends CustomOAuth2
         $userProfile->displayName = $data->get('name') ?: $data->get('preferred_username');
         $userProfile->photoURL    = $data->get('picture');
         $userProfile->email       = $data->get('email');
+        $userProfile->data['preferred_username'] = $data->get('preferred_username');
         if (null !== $groups = $this->getGroups($data)) {
             $userProfile->data['groups'] = $groups;
         }

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -76,6 +76,10 @@ $providersData = [
                 'type' => 'text',
                 'required' => false,
             ],
+            'usePreferredUsername' => [
+                'title' => 'Use preferred_username',
+                'type' => 'checkbox',
+            ],
         ]
     ],
     'custom_oauth2' => [
@@ -215,7 +219,8 @@ $styleClass = [
                             <input
                                 type="<?php p($fieldData['type'])?>"
                                 name="<?php p($provType)?>_providers[<?php p($k) ?>][<?php p($fieldName)?>]"
-                                value="<?php p($provider[$fieldName]) ?>"
+                                value="<?php p($fieldData['type'] === 'checkbox' ? '1' : $provider[$fieldName]) ?>"
+                                <?php p($fieldData['type'] === 'checkbox' && $provider[$fieldName] === '1' ? 'checked' : '') ?> 
                                 <?php p($fieldName === 'name' ? 'readonly' : ($fieldData['required'] ? 'required' : '' )) ?>
                             />
                         </label>
@@ -355,6 +360,7 @@ $styleClass = [
             <input
                 type="<?php p($fieldData['type'])?>"
                 name="<?php p($provType) ?>_providers[{{provider_id}}][<?php p($fieldName) ?>]"
+                value="<?php p($fieldData['type'] === 'checkbox' ? '1' : '') ?>"
                 <?php p($fieldData['required'] ? 'required' : '' ) ?>
             />
         </label>


### PR DESCRIPTION
This adds a feature to trust the `preferred_username` claim from OpenID Connect providers. Keycloak, at least, supports this.

This is useful for environments where we provision nextcloud users using the OIDC provider, and want the usernames to be legible/meaningful. So my user id can be "steve" instead of e.g. "keycloak-de25e39c-0981-43aa-b572-a351aaa012e2".

I didn't add any logic to auto-connect social accounts with oc_sociallogin_connect, or try to resolve existing users or duplicate emails.