### PR TITLE
Change nextcloud ID field

### DIFF
--- a/lib/Provider/CustomOpenIDConnect.php
+++ b/lib/Provider/CustomOpenIDConnect.php
@@ -32,8 +32,8 @@ class CustomOpenIDConnect extends CustomOAuth2
         $data = new Data\Collection($user);
 
         $userProfile = new User\Profile();
-        $userProfile->identifier  = $data->get('sub');
-        $userProfile->displayName = $data->get('name') ?: $data->get('preferred_username');
+        $userProfile->identifier  = $data->get('preferred_username') ?: $data->get('sub');
+        $userProfile->displayName = $data->get('name');
         $userProfile->photoURL    = $data->get('picture');
         $userProfile->email       = $data->get('email');
         if (null !== $groups = $this->getGroups($data)) {


### PR DESCRIPTION
This pulls the preferred username first (some users like their usernames, and want that to be displayed), and if that's not available, pulls the KeycloakID