### PR TITLE
Add Japanese translation

### DIFF
--- a/l10n/ja_JP.js
+++ b/l10n/ja_JP.js
@@ -1,0 +1,29 @@
+OC.L10N.register(
+  "sociallogin",
+  {
+    "Disable auto create new users": "新規ユーザーの自動生成を無効にする",
+    "Create users with disabled account": "無効状態で新規ユーザー作成",
+    "Allow users to connect social logins with their account": "ユーザーが自分のアカウントにソーシャルログインを接続できるようにする",
+    "Prevent creating an account if the email address exists in another account": "メールアドレスに登録されている場合、新しいユーザーを自動的に作成しない",
+    "Update user profile every login": "ログインするたびにユーザー情報を自動的に更新",
+    "Do not prune not available user groups on login": "ログイン時に利用できないユーザーグループを削除しない",
+    "Automatically create groups if they do not exists": "グループが存在しない場合は自動的に作成",
+    "Restrict login for users without mapped groups": "グループに割り当てられていないユーザーのログインを制限",
+    "Disable notify admins about new users": "新規ユーザーに関する管理者への通知を無効",
+
+    "None": "なし",
+    "Save": "保存",
+    "Internal name": "内部名",
+    "Title": "名前",
+    "Authorize url": "認証URL",
+    "User info URL (optional)": "ユーザー情報URL(オプション)",
+    "Default group": "デフォルトグループ",
+    "Add group mapping": "グループマッピングを追加",
+    "Custom OAuth2": "カスタムOAuth2",
+
+    "Settings for social login successfully saved": "ソーシャルログインの設定が保存されました",
+    "Do you realy want to remove {providerTitle} provider ?": "{providerTitle}プロバイダーを削除してもよろしいですか？",
+    "Some error occurred while saving settings": "保存時にエラーが発生しました",
+    "Confirm remove": "削除しますか"
+  },
+"nplurals=1; plural=0;");

--- a/l10n/ja_JP.json
+++ b/l10n/ja_JP.json
@@ -1,0 +1,27 @@
+{ "translations": {
+  "Social login": "ソーシャルログイン",
+  "Enabled": "有効",
+  "Unknown %s provider: \"%s\"": "不明な %s プロバイダー: \"%s\"",
+  "Auto creating new users is disabled": "新規ユーザーを無効で自動作成",
+  "This account already connected": "このアカウントは既に接続済みです",
+  "Provider name cannot be empty": "プロバイダー名は空にできません",
+  "Duplicate provider name \"%s\"": "プロバイダー名\"%s\"が重複しています",
+  "Invalid provider name \"%s\". Allowed characters \"0-9a-z_.@-\"": "プロバイダー名\"%s\"が不正です. \"0-9a-z_.@-\"が利用可能な文字です",
+  "Social login connect": "ソーシャルログイン接続",
+  "Available providers": "利用可能プロバイダー",
+  "Social login connect is disabled": "ソーシャルログインは無効",
+  "Email already registered": "既に登録されているメールアドレスです",
+  "Disable password confirmation on settings change": "設定変更時のパスワード確認を無効にする",
+  "New user created": "新規ユーザーが追加されました",
+  "Your user group is not allowed to login, please contact support": "あなたの属しているグループはログイン許可がありません、サポートへ連絡してください",
+  "User %s (%s) just created via social login": "ユーザー %s (%s) がソーシャルログイン経由で作成されました",
+  "Internal name": "内部名",
+  "Title": "名前",
+  "Authorize url": "認証URL",
+  "User info URL (optional)": "ユーザー情報URL (オプション)",
+  "Default group": "デフォルトグループ",
+  "Add group mapping": "グループマッピングを追加",
+  "Custom OAuth2": "カスタム OAuth2",
+  "Log in with %s": "%s でログイン"
+},"pluralForm" :"nplurals=2; plural=(n > 1);"
+}


### PR DESCRIPTION
Since the use of social-login is increasing in Japan, we added a file to translate the menu into Japanese.

Added Japanese l10n files.
        ja_JP.js
        ja_JP.json

Let me know if there's a problem.