### PR TITLE
Add displayName for groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Also nested claims is supported. For example `resource_access.client-id.roles` f
 }
 ```
 
+There is also support for setting the displayName:
+```
+{"roles": [{gid: 1, displayName: "admin"}, {gid: 2, displayName: "user"}]}
+```
+
 
 You can use provider groups in two ways:
 

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -422,16 +422,13 @@ class ProviderService
                     if(is_object($v)) {
                         $group = $v;
                     } else {
-                        $group = (object) array('gid' => $v, 'displayName' => $v);
+                        $group = (object) array('gid' => $v);
                     }
 
                     if ($groupMapping && isset($groupMapping[$group->gid])) {
-                        $syncGroups[] = $groupMapping[$group->gid];
+                        $syncGroups[] = (object) array('gid' => $groupMapping[$group->gid]);
                     }
                     $autoGroup = $newGroupPrefix.$group->gid;
-                    if($group->gid == $group->displayName) {
-                        $group->displayName = $autoGroup;
-                    }
                     $group->gid = $autoGroup;
                     if ($autoCreateGroups || $this->groupManager->groupExists($group->gid)) {
                         $syncGroups[] = $group;
@@ -449,7 +446,10 @@ class ProviderService
                 foreach ($syncGroups as $group) {
                     if ($newGroup = $this->groupManager->createGroup($group->gid)) {
                         $newGroup->addUser($user);
-                        $newGroup->setDisplayName($group->displayName);
+
+                        if(isset($group->displayName)) {
+                            $newGroup->setDisplayName($group->displayName);
+                        }
                     }
                 }
 

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -420,6 +420,9 @@ class ProviderService
 
                 foreach ($groups as $k => $v) {
                     if(is_object($v)) {
+                        if(!isset($v->gid)) {
+                            continue;
+                        }
                         $group = $v;
                     } else {
                         $group = (object) array('gid' => $v);

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -423,6 +423,9 @@ class ProviderService
                         if(!isset($v->gid)) {
                             continue;
                         }
+                        if (empty($v->gid)) {
+                            continue;
+                        }
                         $group = $v;
                     } else {
                         $group = (object) array('gid' => $v);


### PR DESCRIPTION
Nextcloud support the possibility to set the `displayName` for a group. This is useful when the groups can have changing names, then names are not useful as identifier (since this will change the real group every time the group name changes, causing all links and maps to break). For this it is useful to have the group id to be the identifier but for the user itself to see the `displayName`. 

This PR is backwards compatible, so we can still provide something without a `displayName` but as soon as the `displayName` is added this will be synchronized. 