### PR TITLE
show default login via button

### DIFF
--- a/css/hide_default_login.css
+++ b/css/hide_default_login.css
@@ -1,1 +1,4 @@
 #body-login main div:first-child {display:none}
+#body-login a[href*='#body-login'] {background-color:inherit;color:#fff;font-size:inherit;font-weight:inherit}
+#body-login:target main div:first-child {display:inherit}
+#body-login:target a[href*='#body-login'] {display:none}

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -17,6 +17,7 @@
   "New user created": "Neuer Benutzer angelegt",
   "Your user group is not allowed to login, please contact support": "Ihre Benutzergruppe darf sich nicht anmelden, bitte kontaktieren Sie den technischen Support",
   "User %s (%s) just created via social login": "Benutzer %s (%s) wurde gerade via Social Login angelegt",
-  "Log in with %s": "Anmelden mit %s"
+  "Log in with %s": "Anmelden mit %s",
+  "Log in with username or email": "Mit Benutzernamen oder Passwort anmelden"
 },"pluralForm" :"nplurals=2; plural=(n > 1);"
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -111,6 +111,10 @@ class Application extends App implements IBootstrap
             && $config->getAppValue($this->appName, 'hide_default_login');
         if ($hideDefaultLogin && $request->getPathInfo() === '/login') {
             Util::addStyle($this->appName, 'hide_default_login');
+            \OC_App::registerLogin([
+                'href' => '#body-login',
+                'name' => $l->t('Log in with username or email'),
+            ]);
         }
     }
 


### PR DESCRIPTION
Extension to #233 (hide default login): 
Adds a button labeled "Log in with username or email" below the alternative login buttons to show the default login (so you don't need to know `showDefault=true`.

![Unbenannt](https://user-images.githubusercontent.com/12428377/110029115-5acba900-7d34-11eb-8776-6f77c8cc249b.PNG)

- Register new login with `'href' => '#body-login'`
- Use some CSS magic to show/hide things (`#body-login:target`)

Feature? One could use only `#body-login a[href*='#body-login'] {background-color:inherit}` so the link would be barely visible.
![Unbenannt2](https://user-images.githubusercontent.com/12428377/110029132-60c18a00-7d34-11eb-9075-177bcf54dba1.PNG)





