### PR TITLE
Allow login via email with different UID

### DIFF
--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -373,8 +373,14 @@ class ProviderService
     {
         $user = $this->userManager->get($uid);
         if (null === $user) {
-            $connectedUid = $this->socialConnect->findUID($uid);
-            $user = $this->userManager->get($connectedUid);
+            // search user by email
+            if (count($this->userManager->getByEmail($profile->email)) === 1) {
+                $user = $this->userManager->getByEmail($profile->email)[0];
+            }
+            else {
+                $connectedUid = $this->socialConnect->findUID($uid);
+                $user = $this->userManager->get($connectedUid);
+            }
         }
         if ($this->userSession->isLoggedIn()) {
             if (!$this->config->getAppValue($this->appName, 'allow_login_connect')) {

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -362,7 +362,7 @@ class ProviderService
         if ($provider === 'telegram') {
             $provider = 'tg'; //For backward compatibility
         }
-        $uid = $provider.'-'.$profileId;
+        $uid = $profile->email;
         if (strlen($uid) > 64 || !preg_match('#^[a-z0-9_.@-]+$#i', $profileId)) {
             $uid = $provider.'-'.md5($profileId);
         }


### PR DESCRIPTION
Hi and thank you for your great work with this plugin.
Just here to mention this few modifications we did in order to be able to authenticate users that already exist in Nextcloud, have uid != email and authenticate via OAuth2 using the email. This allows us to match the existing user to the one authenticated via OAuth2.
Maybe you could move this code to and if-driven conditional and add a specific setting.