### PR TITLE
Seznam.cz login use oauth_user_id

### DIFF
--- a/lib/Provider/CustomOAuth2.php
+++ b/lib/Provider/CustomOAuth2.php
@@ -46,6 +46,7 @@ class CustomOAuth2 extends OAuth2
                 ?? $response->data->id
                 ?? $response->user_id
                 ?? $response->userId
+                ?? $response->oauth_user_id
                 ?? null
             ;
         }


### PR DESCRIPTION
Seznam.cz login now provide stable user id which can be used as identifier but the name is not one of supported here so I want to add it to be able to use this service.

For reference you can see https://vyvojari.seznam.cz/oauth/scopes.