### PR TITLE
fix(login): take custom webroot into account when redirecting

### DIFF
--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -589,6 +589,11 @@ class ProviderService
         \OC::$server->get(\OCP\Files\IRootFolder::class)->getUserFolder($user->getUID());
 
         if ($redirectUrl = $this->session->get('login_redirect_url')) {
+            if (strpos($redirectUrl, '/') === 0) {
+                // URL relative to the Nextcloud webroot, generate an absolute one
+                $redirectUrl = $this->urlGenerator->getAbsoluteURL($redirectUrl);
+            } // else, this is an absolute URL, leave it as-is
+
             return new RedirectResponse($redirectUrl);
         }
 


### PR DESCRIPTION
Hello,

This PR fixes an issue I have been encountering on my Nextcloud deployment.

The issue is as follows:
* Nextcloud is hosted at https://my.domain/nextcloud/
* SSO (Keycloak) is hosted at https://sso.my.domain/

Nextcloud is configured with the following options:
```php
'overwritewebroot' => 'nextcloud',
'overwriteprotocol' => 'https',
'overwritehost' => 'my.domain'
```

When trying to reach a restricted page (for example, trying to reach the calendar at https://my.domain/nextcloud/apps/calendar/), the following happens
* Redirect to Nextcloud login page (with ?redirect_url=/apps/calendar/)
* Picking Keycloak login (from this plugin) redirects to Keycloak
* After logging in, Keycloak redirects to the Social login callback (with ?login_redirect_url=/apps/calendar)
* Social login redirects to /apps/calendar => which isn't the Nextcloud instance

This can be fixed by redirecting to `\OC::$WEBROOT . $redirect_url`, where `\OC::$WEBROOT` is the Nextcloud variable holding the web root.

I have tested this fix on my instance, it does solve the issue.