### PR TITLE
Read display_name value to work with Wordpress OAuth providers

### DIFF
--- a/lib/Provider/CustomOAuth2.php
+++ b/lib/Provider/CustomOAuth2.php
@@ -56,6 +56,7 @@ class CustomOAuth2 extends OAuth2
         $displayNameClaim = $this->config->get('displayname_claim');
         $response->displayName = $response->$displayNameClaim
             ?? $response->displayName
+            ?? $response->display_name
             ?? $response->username
             ?? null
         ;

--- a/lib/Provider/CustomOpenIDConnect.php
+++ b/lib/Provider/CustomOpenIDConnect.php
@@ -35,7 +35,7 @@ class CustomOpenIDConnect extends CustomOAuth2
 
         $userProfile = new User\Profile();
         $userProfile->identifier  = $data->get('sub');
-        $userProfile->displayName = $data->get($displayNameClaim) ?: $data->get('name') ?: $data->get('preferred_username');
+        $userProfile->displayName = $data->get($displayNameClaim) ?: $data->get('display_name') ?: $data->get('name') ?: $data->get('preferred_username');
         $userProfile->photoURL    = $data->get('picture');
         $userProfile->email       = $data->get('email');
         if (!is_string($userProfile->photoURL)) {
@@ -57,7 +57,7 @@ class CustomOpenIDConnect extends CustomOAuth2
             if (empty($userProfile->identifier)) {
                 $userProfile->identifier = $profile->get('sub');
             }
-            $userProfile->displayName = $profile->get($displayNameClaim) ?: $profile->get('name') ?: $profile->get('preferred_username') ?: $profile->get('nickname');
+            $userProfile->displayName = $profile->get($displayNameClaim) ?: $profile->get('display_name') ?: $profile->get('name') ?: $profile->get('preferred_username') ?: $profile->get('nickname');
             if (!$userProfile->photoURL) {
                 $userProfile->photoURL = $profile->get('picture') ?: $profile->get('avatar');
             }


### PR DESCRIPTION
Using CustomOauth2 and CustomOpenID providers with wordpress does not retrieve user display name.
Wordpress is using `display_name` keyword on WPUser datas, and it's the one exposed by OAuth providers plugins.

I'm just adding this value as alternative if not found.
Tested with https://wp-oauth.com/ plugin

Thanks for your work !