### PR TITLE
fix malformed redirectUrl with query param

### DIFF
--- a/js/telegram.js
+++ b/js/telegram.js
@@ -14,7 +14,15 @@ document.addEventListener('DOMContentLoaded', function () {
       e.preventDefault()
       Telegram.Login.auth({bot_id: botId}, function (data) {
         if (data) {
-          location = redirectUrl + '?' + new URLSearchParams(data)
+          try {
+            var redirectObj = new URL(redirectUrl)
+            new URLSearchParams(data).forEach((v, k) => {
+              redirectObj.searchParams.set(k, v)
+            })
+            location = redirectObj.href
+          } catch (TypeError) {
+            location = redirectUrl + '?' + new URLSearchParams(data)
+          }
           document.body.style.display = 'none'
         }
       })

--- a/js/telegram.js
+++ b/js/telegram.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', function () {
               redirectObj.searchParams.set(k, v)
             })
             location = redirectObj.href
-          } catch (TypeError) {
+          } catch (err) {
             location = redirectUrl + '?' + new URLSearchParams(data)
           }
           document.body.style.display = 'none'


### PR DESCRIPTION
**Telegram Login flow**
When the login url already has a query param (e.g. https://<DOMAIN_NAME>/login?redirect_url=/apps/calendar), the redirect url (after the login process) is obtained by a simple concatenation of the `?` symbol, without checking if the original url already contains query parameters, thus making the final url malformed and blocking the login flow with an error.
![immagine](https://github.com/zorn-v/nextcloud-social-login/assets/28732212/9e00f888-8f80-4422-9160-d4642c33655b)


This fix wraps the redirectUrl into an URL object and adds all params using the provided method. Moreover, all params are now url-encoded.