### PR TITLE
CustomOauth2 add more identifier and displayName variants

### DIFF
--- a/lib/Provider/CustomOAuth2.php
+++ b/lib/Provider/CustomOAuth2.php
@@ -52,6 +52,7 @@ class CustomOAuth2 extends OAuth2
                 ?? $response->userId
                 ?? $response->oauth_user_id
                 ?? $response->sub
+                ?? $response->client_id
                 ?? null
             ;
         }
@@ -59,6 +60,7 @@ class CustomOAuth2 extends OAuth2
         $response->displayName = $response->$displayNameClaim
             ?? $response->displayName
             ?? $response->username
+            ?? $response->name
             ?? null
         ;
 


### PR DESCRIPTION
Possibly fixes biz.mail.ru authorization through Custom OAuth2 provider.
As described in [documentation](https://biz.mail.ru/developer/oauth.html) they use `client_id` field as identifier and `name` as displayName.
<img width="450" alt="Screenshot 2023-10-16 at 17 08 12" src="https://github.com/zorn-v/nextcloud-social-login/assets/53442263/7e8bfbe0-d28f-44ba-9fdb-c989a2183279">
