### PR TITLE
Change group string split

### DIFF
--- a/lib/Provider/CustomOAuth2.php
+++ b/lib/Provider/CustomOAuth2.php
@@ -90,7 +90,7 @@ class CustomOAuth2 extends OAuth2
     protected function getGroups(Data\Collection $data)
     {
         if ($groupsClaim = $this->config->get('groups_claim')) {
-            $nestedClaims = explode('.', $groupsClaim);
+            $nestedClaims = str_getcsv($groupsClaim, '.','"');
             $claim = array_shift($nestedClaims);
             $groups = $data->get($claim);
             while (count($nestedClaims) > 0) {


### PR DESCRIPTION
Our SSO system uses a dot in one of the claim names. This creates a conflict with how the group string is processed in the settings. To resolve this, we can use the str_getcsv function, which allows us to enclose a portion of the string that should not be divided.