### PR TITLE
Add scope header in OAuth2

### DIFF
--- a/lib/Provider/CustomOAuth2.php
+++ b/lib/Provider/CustomOAuth2.php
@@ -39,7 +39,7 @@ class CustomOAuth2 extends OAuth2
             $profileUrl .= (strpos($profileUrl, '?') !== false ? '&' : '?') . 'fields=' . implode(',', $profileFields);
         }
 
-        $response = $this->apiRequest($profileUrl);
+        $response = $this->apiRequest($profileUrl, headers: ["X-Scope" => $this->config->get('scope')]);
         if (isset($response->ocs->data)) {
             $response = $response->ocs->data;
         }


### PR DESCRIPTION
We have a custom OAuth2 provider that only returns the scopes if the header `X-Scope` is set as well.

This PR sets the settings-defined scope in that header.