### PR TITLE
fix: actually check if user has groups assigned

### DIFF
--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -466,7 +466,7 @@ class ProviderService
         return $this->login($uid, $profile, $provider.'-');
     }
 
-        private function login($uid, Profile $profile, $newGroupPrefix = '')
+    private function login($uid, Profile $profile, $newGroupPrefix = '')
     {
         $user = $this->userManager->get($uid);
         if (null === $user) {

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -485,8 +485,14 @@ class ProviderService
             return new RedirectResponse($this->urlGenerator->linkToRoute('settings.PersonalSettings.index', ['section'=>'sociallogin']));
         }
 
-        if ($this->config->getAppValue($this->appName, 'restrict_users_wo_assigned_groups') && empty($profile->data['groups'])) {
-            throw new LoginException($this->l->t('Users without assigned groups is not allowed to login, please contact support'));
+        $jwtGroups = $profile->data['groups'] ?? [];
+        $nextcloudGroups = $this->groupManager->getUserGroups($user);
+        $isInGroup = !empty($nextcloudGroups) || !empty($jwtGroups);
+    
+        if ($this->config->getAppValue($this->appName, 'restrict_users_wo_assigned_groups')) {
+            if (!$isInGroup) {
+                throw new LoginException($this->l->t('Users without assigned groups is not allowed to login, please contact support'));
+            } 
         }
 
         if ($this->config->getAppValue($this->appName, 'restrict_users_wo_mapped_groups') && isset($profile->data['group_mapping'])) {


### PR DESCRIPTION
The option 'Restrict users w/o assigned groups' did not work because the actual group assignments were not fetched from the user database.