### PR TITLE
Fix open redirect via login_redirect_url (fixes #542)

### DIFF
--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -601,17 +601,44 @@ class ProviderService
         \OC::$server->get(\OCP\Files\IRootFolder::class)->getUserFolder($user->getUID());
 
         if ($redirectUrl = $this->session->get('login_redirect_url')) {
-            if (strpos($redirectUrl, '/') === 0) {
-                // URL relative to the Nextcloud webroot, generate an absolute one
-                $redirectUrl = $this->urlGenerator->getAbsoluteURL($redirectUrl);
-            } // else, this is an absolute URL, leave it as-is
-
-            return new RedirectResponse($redirectUrl);
+            $safeRedirectUrl = $this->getSafeInternalRedirectUrl($redirectUrl);
+            if ($safeRedirectUrl !== null) {
+                return new RedirectResponse($safeRedirectUrl);
+            }
+            // Untrusted (off-site) URL: ignore it and fall through to the default.
         }
 
         $this->session->set('last-password-confirm', time());
 
         return new RedirectResponse($this->urlGenerator->getAbsoluteURL('/'));
+    }
+
+    /**
+     * Resolve a stored `login_redirect_url` to a URL that is guaranteed to point
+     * at this Nextcloud instance, or null if it does not. This prevents an open
+     * redirect: `login_redirect_url` is read from an unauthenticated request and
+     * was previously reflected verbatim into a Location header for any absolute
+     * URL, allowing `.../apps/sociallogin/oauth/<provider>?login_redirect_url=https://evil.example`
+     * to bounce a freshly-authenticated victim off-site.
+     */
+    private function getSafeInternalRedirectUrl(string $redirectUrl): ?string
+    {
+        // Path relative to the Nextcloud webroot, but not a protocol-relative
+        // "//host" or a "/\host" backslash trick that browsers treat as a host.
+        if (strpos($redirectUrl, '/') === 0
+            && strpos($redirectUrl, '//') !== 0
+            && strpos($redirectUrl, '/\\') !== 0
+        ) {
+            return $this->urlGenerator->getAbsoluteURL($redirectUrl);
+        }
+
+        // Absolute URL: only honor it when it targets this very instance.
+        $base = rtrim($this->urlGenerator->getAbsoluteURL('/'), '/');
+        if ($redirectUrl === $base || strpos($redirectUrl, $base . '/') === 0) {
+            return $redirectUrl;
+        }
+
+        return null;
     }
 
     private function notifyAdmins($uid, $displayName, $groupId)


### PR DESCRIPTION
## Fix open redirect via `login_redirect_url`

Fixes #542.

### Problem
The `login_redirect_url` query parameter is read from an **unauthenticated** request (`ProviderService::oauth`/`custom`, both `#[PublicPage] #[NoCSRFRequired]`), stored in the session, and after a successful external login was reflected **verbatim** into a `RedirectResponse` for any absolute URL:

```php
if ($redirectUrl = $this->session->get('login_redirect_url')) {
    if (strpos($redirectUrl, '/') === 0) {
        $redirectUrl = $this->urlGenerator->getAbsoluteURL($redirectUrl);
    } // else, this is an absolute URL, leave it as-is
    return new RedirectResponse($redirectUrl);
}
```

So a request such as

```
https://victim.example/apps/sociallogin/oauth/<provider>?login_redirect_url=https://evil.example/phish
```

bounces a victim who authenticates legitimately to an attacker-controlled site (phishing / post-login relay). A scheme is required (`//evil` starts with `/` and is treated as relative), e.g. `https://evil.example`.

### Fix
Only redirect to **this** Nextcloud instance. A new helper `getSafeInternalRedirectUrl()` accepts:
- webroot-relative paths (`/...`), rejecting `//host` and `/\host` browser host tricks; and
- absolute URLs whose origin is exactly this instance.

Anything else is ignored and the flow falls back to the default landing page.

### Testing
Standalone verification of the redirect decision (attack + legitimate vectors), all passing:

| input | result |
|---|---|
| `https://evil.example/phish` | blocked |
| `//evil.example/x` | blocked |
| `/\evil.example` | blocked |
| `https://<instance>.evil.com/x` (suffix trick) | blocked |
| `https://<instance>@evil.com/x` (userinfo trick) | blocked |
| `http://127.0.0.1/x` | blocked |
| `/apps/files/`, `/settings/user?x=1` | allowed (same instance) |
| `https://<instance>/apps/files` | allowed (same origin) |

`php -l` clean. No behavior change for legitimate same-instance redirects.

*🤖 Disclosure: prepared by Claude Code – Opus 4.8 (xhigh)*
